### PR TITLE
chore: update GitHub Actions versions and set up Codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source = dbttoolkit
+
+[report]
+exclude_lines =
+    if self.debug:
+    pragma: no cover
+    raise NotImplementedError
+    if __name__ == .__main__.:
+ignore_errors = True
+omit =
+    tests/*

--- a/.github/workflows/publish-package.yaml
+++ b/.github/workflows/publish-package.yaml
@@ -8,10 +8,10 @@ jobs:
   publish-package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8.x'
 

--- a/.github/workflows/run-code-checks.yaml
+++ b/.github/workflows/run-code-checks.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8.x'
 
@@ -22,7 +22,7 @@ jobs:
         run: pip3 install pipenv
 
       - name: Cache Python packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs/
           key: ${{ runner.os }}-python-${{ hashFiles('**/Pipfile.lock') }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8.x'
 
@@ -22,13 +22,13 @@ jobs:
         run: pip3 install pipenv
 
       - name: Cache Python packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.local/share/virtualenvs/
           key: ${{ runner.os }}-python-${{ hashFiles('**/Pipfile.lock') }}
 
       - name: Install Python dependencies
-        run: pipenv install --dev  --deploy
+        run: pipenv install --dev --deploy
 
       - name: Install this package
         run: pipenv run pip3 install .


### PR DESCRIPTION
Getting rid of the following warning:

```[run-tests](https://github.com/voi-oss/dbt-toolkit/actions/runs/4831710430/jobs/8609509204)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2, actions/cache@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.```