### PR TITLE
fix: handle cancelled jobs

### DIFF
--- a/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
+++ b/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
@@ -1,8 +1,7 @@
+import requests
 from dataclasses import dataclass
 from datetime import datetime
 from typing import ClassVar, Dict, Iterable, List, Mapping, Optional
-
-import requests
 
 from dbttoolkit.utils.logger import get_logger
 
@@ -144,6 +143,7 @@ class DbtCloudClient:
             run
             for run in runs
             if run["is_complete"]
+            and not run["is_cancelled"]
             and run["project_id"] == self.project_id
             and run["environment_id"] == self.environment_id
         ]

--- a/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
+++ b/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
@@ -1,7 +1,8 @@
-import requests
 from dataclasses import dataclass
 from datetime import datetime
 from typing import ClassVar, Dict, Iterable, List, Mapping, Optional
+
+import requests
 
 from dbttoolkit.utils.logger import get_logger
 

--- a/tests/dbt_cloud/actions/test_retrieve_most_recent_artifact.py
+++ b/tests/dbt_cloud/actions/test_retrieve_most_recent_artifact.py
@@ -59,6 +59,16 @@ def rest_api_run_result(job_id, dbt_cloud_ids):
         "id": 2,
         "is_complete": True,
         "is_success": False,
+        "is_cancelled": False,
+        "created_at": "2022-06-10 11:30:00.321339+00:00",
+        **common,
+    }
+
+    cancelled = {
+        "id": 3,
+        "is_complete": True,
+        "is_success": False,
+        "is_cancelled": True,
         "created_at": "2022-06-10 11:30:00.321339+00:00",
         **common,
     }
@@ -67,11 +77,12 @@ def rest_api_run_result(job_id, dbt_cloud_ids):
         "id": 1,
         "is_complete": True,
         "is_success": True,
+        "is_cancelled": False,
         "created_at": "2022-06-09 11:30:00.321339+00:00",
         **common,
     }
 
-    return {"data": [failure, success]}
+    return {"data": [failure, cancelled, success]}
 
 
 @fixture


### PR DESCRIPTION
There was an incident on dbt Cloud where they cancelled a few of our jobs, and it broke the Airflow job using this command. This PR updates the code to handle cancelled jobs gracefully. Since cancelled jobs on dbt Cloud do not generate artifacts, we simply skip them.

Error message: 
```
[2023-08-29, 16:21:13 CEST] {pod_manager.py:235} INFO -   File "/app/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py", line 40, in <listcomp>
[2023-08-29, 16:21:13 CEST] {pod_manager.py:235} INFO -     if datetime.fromisoformat(run["finished_at"]) >= start_time
[2023-08-29, 16:21:13 CEST] {pod_manager.py:235} INFO - TypeError: fromisoformat: argument must be str
```

Reproduced and tested locally.