### PR TITLE
feat(dbt cloud): Changing page size

### DIFF
--- a/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
+++ b/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
@@ -8,7 +8,6 @@ from dbttoolkit.utils.logger import get_logger
 
 logger = get_logger()
 
-LARGE_PAGE_SIZE = 2000
 STANDARD_PAGE_SIZE = 100
 
 
@@ -35,8 +34,7 @@ class DbtCloudClient:
         """
         logger.info(f"Retrieving all production runs (between {start_time} and {end_time})")
 
-        # As of 2021-08, a page size of 2000 will give us around 1 month worth of runs
-        completed_runs = self.retrieve_completed_runs(page_size=LARGE_PAGE_SIZE, created_after=start_time)
+        completed_runs = self.retrieve_completed_runs(created_after=start_time)
         runs = [
             run
             for run in completed_runs

--- a/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
+++ b/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
@@ -97,7 +97,6 @@ class DbtCloudClient:
         response.raise_for_status()
         return response.json()
 
-
     def retrieve_completed_runs(
         self, *, page_size: int = STANDARD_PAGE_SIZE, created_after: datetime = None
     ) -> List[Dict]:

--- a/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
+++ b/src/dbttoolkit/dbt_cloud/clients/dbt_cloud_client.py
@@ -89,19 +89,14 @@ class DbtCloudClient:
         if step:
             params = {"step": step}
 
-        try:
-            response = requests.get(
-                self.BASE_URL + f"/accounts/{self.account_id}/runs/{run_id}/artifacts/{artifact_name}.json",
-                params=params,
-                headers=self._default_headers(),
-            )
-            response.raise_for_status()
-            return response.json()
+        response = requests.get(
+            self.BASE_URL + f"/accounts/{self.account_id}/runs/{run_id}/artifacts/{artifact_name}.json",
+            params=params,
+            headers=self._default_headers(),
+        )
+        response.raise_for_status()
+        return response.json()
 
-        except requests.exceptions.RequestException as e:
-            logger.error(f"Error making API request: {e}")
-            # Handle the error or re-raise it if necessary
-            raise
 
     def retrieve_completed_runs(
         self, *, page_size: int = STANDARD_PAGE_SIZE, created_after: datetime = None
@@ -125,15 +120,10 @@ class DbtCloudClient:
                 "include_related": '["job", "environment", "trigger"]',
             }
 
-            try:
-                response = requests.get(
-                    self.BASE_URL + f"/accounts/{self.account_id}/runs", params=params, headers=self._default_headers()
-                )
-                response.raise_for_status()
-            except requests.exceptions.RequestException as e:
-                logger.error(f"Error making API request: {e}")
-                # Handle the error or re-raise it if necessary
-                raise
+            response = requests.get(
+                self.BASE_URL + f"/accounts/{self.account_id}/runs", params=params, headers=self._default_headers()
+            )
+            response.raise_for_status()
 
             data = response.json()["data"]
             runs += data


### PR DESCRIPTION
Currently, page_size is set to 500. According to the dbt announcement email (search for Action required: API Request Limits in dbt Cloud in your inbox), from December 2023, it will only return 100 records. So, we need to change the default value for page_size to 100.